### PR TITLE
Feature/fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
-# molecule
+# ⚛️ molecule
 
-A new Flutter project.
+> Independent native editor
 
-## Getting Started
+## ❓ What is molecule?
+Molecule is an independent native text editor.
 
-This project is a starting point for a Flutter application.
+## 💻 Why not VSCode?
+VSCode is without a doubt a very good editor, unfortunately it has one major drawback. Electron. Electron is a ramhog, so VSCode already gets a very high RAM load with little work.
 
-A few resources to get you started if this is your first Flutter project:
+## 🧩 Plugin Support
+Plugin support for Molecule is planned. However, the focus is currently on other things.
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+## 🖌️ Theme Support
+Like plugin support, user theme support is also planned and will be implemented very soon.
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+## 🐧 Why are there only binaries for Linux?
+I only use Linux as my operating system. The other platforms like MacOS or Windows do not interest me. But everyone is free to compile the code for these platforms.

--- a/lib/core/config.dart
+++ b/lib/core/config.dart
@@ -4,8 +4,10 @@
 
 import 'dart:convert';
 
+import 'package:flutter/cupertino.dart';
 import 'package:json2yaml/json2yaml.dart';
 import 'package:molecule/core/init.dart' show getConfigDir;
+import 'package:molecule/utils/converter.dart';
 import 'dart:io' show File;
 
 import 'package:yaml/yaml.dart' show loadYaml, YamlMap;
@@ -15,7 +17,29 @@ class Config {
   Config() {
     content = getConfigData();
   }
+
+  FontSettings get fontSettings {
+    return FontSettings(content["font"]);
+  }
 }
+
+class FontSettings {
+  final Map<String, dynamic> fontSettings;
+  FontSettings(this.fontSettings);
+
+  String? get fontFamily => fontSettings["family"];
+  get fontSize => fontSettings["size"] ?? 13.0;
+  bool get fontLigatures => fontSettings["ligatures"] ?? false;
+  FontWeight? get fontWeight {
+    if (fontSettings["weight"] != null) {
+      return weightToFontWeight(fontSettings["weight"]);
+    } else {
+      return FontWeight.normal;
+    }
+  }
+}
+
+final moleculeConfig = Config();
 
 /// get config file data
 Map<String, dynamic> getConfigData() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,20 +2,22 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:molecule/core/state.dart';
 import 'package:molecule/screens/editor.dart';
+import 'package:molecule/utils/menubar.dart' show initAppBar;
 
 void main() {
   runApp(UncontrolledProviderScope(
     container: provCot,
-    child: const MyApp(),
+    child: const Molecule(),
   ));
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+class Molecule extends StatelessWidget {
+  const Molecule({Key? key}) : super(key: key);
 
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
+    initAppBar(context);
     return const MaterialApp(
       title: 'Molecule',
       // showPerformanceOverlay: true,

--- a/lib/utils/converter.dart
+++ b/lib/utils/converter.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart' show FontWeight;
+
+FontWeight? weightToFontWeight(int weight) {
+  switch (weight) {
+    case 100:
+      return FontWeight.w100;
+    case 200:
+      return FontWeight.w200;
+    case 300:
+      return FontWeight.w300;
+    case 400:
+      return FontWeight.normal;
+    case 500:
+      return FontWeight.w500;
+    case 600:
+      return FontWeight.w600;
+    case 700:
+      return FontWeight.w700;
+    case 800:
+      return FontWeight.w800;
+    case 900:
+      return FontWeight.w900;
+    default:
+      return null;
+  }
+}

--- a/lib/utils/menubar.dart
+++ b/lib/utils/menubar.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:menubar/menubar.dart'
+    show setApplicationMenu, NativeSubmenu, NativeMenuDivider, NativeMenuItem;
+import 'package:molecule/core/file.dart';
+
+void initAppBar(BuildContext context) {
+  setApplicationMenu(<NativeSubmenu>[
+    NativeSubmenu(label: "File", children: <NativeMenuItem>[
+      NativeMenuItem(label: "Open file", onSelected: () => openFiles())
+    ]),
+    NativeSubmenu(label: "Help", children: [
+      NativeMenuItem(label: "Get help", onSelected: () => ""),
+      NativeMenuItem(label: "Report bug", onSelected: () => ""),
+      NativeMenuItem(label: "Version notes", onSelected: () => ""),
+      const NativeMenuDivider(),
+      NativeMenuItem(
+          label: "About Molecule",
+          onSelected: () => showAboutDialog(
+                context: context,
+                applicationName: "Molecule",
+              ))
+    ])
+  ]);
+}

--- a/lib/widgets/bottombar.dart
+++ b/lib/widgets/bottombar.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:lucide_icons/lucide_icons.dart';
 import 'package:molecule/core/color.dart';
 import 'package:molecule/core/events.dart' show FileTreeToggleNotification;
 import 'package:molecule/core/file.dart';
@@ -35,19 +36,15 @@ class _MoleculeBottomBarState extends State<MoleculeBottomBar> {
                           height: 12,
                           minWidth: 12,
                           padding: EdgeInsets.zero,
-                          child: FaIcon(FontAwesomeIcons.folderTree,
-                              color: MColorScheme.textColor, size: 12),
+                          child: Icon(LucideIcons.folderTree,
+                              color: MColorScheme.textColor, size: 15),
                         )
                       ],
                     ),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.center,
-                      children: [
-                        MaterialButton(
-                            onPressed: () => openFiles(),
-                            child: const Text("OPEN"))
-                      ],
+                      children: const [],
                     ),
                     Row(
                       mainAxisAlignment: MainAxisAlignment.end,

--- a/lib/widgets/filetree.dart
+++ b/lib/widgets/filetree.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:lucide_icons/lucide_icons.dart';
 import 'package:molecule/core/color.dart';
 
 class FileTree extends StatefulWidget {
@@ -20,7 +21,7 @@ class _FileTreeState extends State<FileTree> {
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            FaIcon(FontAwesomeIcons.folderTree, color: MColorScheme.textColor),
+            Icon(LucideIcons.folderTree, color: MColorScheme.textColor),
             SizedBox(
               height: MediaQuery.of(context).size.height * .02,
             ),

--- a/lib/widgets/textarea.dart
+++ b/lib/widgets/textarea.dart
@@ -1,5 +1,8 @@
+import 'dart:ui';
+
 import "package:flutter/material.dart";
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:molecule/core/config.dart' show moleculeConfig;
 import 'package:molecule/core/file.dart';
 import 'package:molecule/core/state.dart';
 
@@ -42,6 +45,15 @@ class _TextAreaState extends ConsumerState<TextArea> {
           return TextField(
             autofocus: false,
             maxLines: null,
+            style: TextStyle(
+                fontFamily: moleculeConfig.fontSettings.fontFamily,
+                fontSize: moleculeConfig.fontSettings.fontSize as double,
+                fontWeight: moleculeConfig.fontSettings.fontWeight,
+                fontFeatures: [
+                  if (!moleculeConfig.fontSettings.fontLigatures) ...[
+                    const FontFeature.disable("calt"),
+                  ]
+                ]),
             controller: _textEditingController,
             decoration: const InputDecoration.collapsed(hintText: ""),
             keyboardType: TextInputType.multiline,

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,13 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <menubar/menubar_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) menubar_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "MenubarPlugin");
+  menubar_plugin_register_with_registrar(menubar_registrar);
   g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
   url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  menubar
   url_launcher_linux
 )
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import menubar
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  MenubarPlugin.register(with: registry.registrar(forPlugin: "MenubarPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -177,6 +177,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  lucide_icons:
+    dependency: "direct main"
+    description:
+      name: lucide_icons
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.83.0"
   matcher:
     dependency: transitive
     description:
@@ -191,6 +198,15 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.4"
+  menubar:
+    dependency: "direct main"
+    description:
+      path: "plugins/menubar"
+      ref: "12decbe0f592e14e03223f6f2c0c7e0e2dbd70a1"
+      resolved-ref: "12decbe0f592e14e03223f6f2c0c7e0e2dbd70a1"
+      url: "https://github.com/google/flutter-desktop-embedding.git"
+    source: git
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -198,13 +214,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
-  ms_undraw:
-    dependency: "direct main"
-    description:
-      name: ms_undraw
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.1.0+2"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,13 @@ dependencies:
   font_awesome_flutter: ^10.1.0
   yaml: ^3.1.1
   json2yaml: ^3.0.0
-  ms_undraw: ^3.1.0+2
   file_picker: ^4.6.1
+  menubar:
+    git:
+      url: https://github.com/google/flutter-desktop-embedding.git
+      path: plugins/menubar
+      ref: 12decbe0f592e14e03223f6f2c0c7e0e2dbd70a1
+  lucide_icons: ^0.83.0
 
 dev_dependencies:
   flutter_test:

--- a/test.txt
+++ b/test.txt
@@ -1,5 +1,0 @@
-<-- these line indicatiors
-
-
-
-

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <menubar/menubar_plugin.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  MenubarPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("MenubarPlugin"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  menubar
   url_launcher_windows
 )
 


### PR DESCRIPTION
# Fonts for Molecule
The editor font can now be set in the Molecule configuration file.

## Example Configuration
```yml
# other config
font:
  family: Fira Code
  size: 16.0
  weight: 400
  ligatures: true
```

- `family`: used to set the font family. Family must be installed on the system or shipped with molecule (default: system font)
- `size`: used to set the size of the font. Default: 13.0
- `weight`: sets the weight of the font (accepting values from 100-900). Default: 400
- `ligatures`: enables font ligatures for your font.

